### PR TITLE
save data just digital docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 
 # Changelog - SchoolServices - ConstHistCert
 
+## [2.4.0] - 2024-02-27
+
+René Alejandro Rivas
+
+### Changed:
+- Academic record unit test updated
+- AcademicRecord controller: validation added to save data just for digital procedures
+- AcademicRecord Service: now validates delivery label and sends a flag to the
+controller to state if delivery is digital or not
+- changeSchoolNameByModality() moved from utilities to AcademicLevelsRepository
+to avoid circular dependency
+- ProofOfStudyService, StudyCertificateService & TransactionNumberService now consume
+changeSchoolNameByModality() from AcademicLevelsRepository
+
 ## [2.3.2] - 2024-02-15
 
 René Alejandro Rivas

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "school-services-consthistcert",
-  "version": "1.54.0",
+  "version": "2.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "school-services-consthistcert",
-      "version": "1.54.0",
+      "version": "2.3.2",
       "dependencies": {
         "@loopback/boot": "^6.1.2",
         "@loopback/core": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "school-services-consthistcert",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "description": "Espacio: SchoolServices CHC microservice",
   "keywords": [
     "loopback-application",

--- a/public/index.html
+++ b/public/index.html
@@ -84,7 +84,7 @@
   <body>
     <div class="info">
       <h1>school-services-consthistcert</h1>
-      <p>Version 2.3.2</p>
+      <p>Version 2.4.0</p>
 
       <h3>OpenAPI spec: <a href="/openapi.json">/openapi.json</a></h3>
       <h3>API Explorer: <a href="/explorer">/explorer</a></h3>

--- a/src/__tests__/unit/controllers/academic-record.unit.ts
+++ b/src/__tests__/unit/controllers/academic-record.unit.ts
@@ -58,7 +58,7 @@ describe('AcademicRecordController', () => {
     it('returns arrays of delivery types and campus', async () => {
       // stubs:
       academicRecordService.stubs.setAcademicRecordServiceProperties.resolves(
-        servicioFields
+        {serviceObject: servicioFields, saveProcedureData: true}
       );
       proceduresService.stubs.requestProcedure.resolves(
         ticketNumberDummy

--- a/src/constants/identifiers.constants.ts
+++ b/src/constants/identifiers.constants.ts
@@ -47,6 +47,8 @@ export const PROGRAMA_DE_ULA_ID = 'ula-institution-social-service';
 
 // Values
 export const CAMPUS_DELIVERY_VALUE = 'ENTE7E2C6';
+export const DIGITAL_UTC_LABEL = "Únicamente en Formato Digital";
+export const DIGITAL_ULA_LABEL = "Únicamente lo requiero en Formato Digital";
 export const TOTAL_STUDY_CERT_VALUE = 'CERC11T5';
 
 // Study Certificate

--- a/src/controllers/academic-record.controller.ts
+++ b/src/controllers/academic-record.controller.ts
@@ -78,9 +78,9 @@ export class AcademicRecordController {
     // FETCH DATA
     const {delivery, campus} =
       await this.academicRecordService.commonPropertiesService.
-      fetchDeliveryAndCampusArrays(
-        studentData.school,
-      );
+        fetchDeliveryAndCampusArrays(
+          studentData.school,
+        );
     // SEND RESPONSE
     const data = {delivery, campus};
     return successfulChcObject(data, 200, getAcademicRecordStatusOk);
@@ -117,15 +117,15 @@ export class AcademicRecordController {
     );
 
     // SET "SERVICIO" FIELDS
-    const servicioObject =
+    const {serviceObject, saveProcedureData} =
       await this.academicRecordService.setAcademicRecordServiceProperties(
         studentData,
         academicRecordRB,
       );
 
-    // SET SF REQUEST BODY
+    // SET SALES FORCE REQUEST BODY
     const sfRequestBody = await this.proceduresService.setSfRequestBody(
-      servicioObject,
+      serviceObject,
       academicRecordRB.files,
       studentData,
       ACADEMIC_RECORD,
@@ -147,7 +147,8 @@ export class AcademicRecordController {
         studentData,
       );
 
-    await this.qrValidationRepository.saveProcedureData(
+    // SAVE PROCEDURE DATA FOR FUTURE VALIDATION
+    if (saveProcedureData) await this.qrValidationRepository.saveProcedureData(
       studentData,
       'Historial Academico',
       ticketNumber

--- a/src/repositories/academic-levels.repository.ts
+++ b/src/repositories/academic-levels.repository.ts
@@ -1,5 +1,6 @@
 import {inject} from '@loopback/core';
 import {DefaultCrudRepository} from '@loopback/repository';
+import {SUBSCHOOL, ULABYUANE, UTC, UTCBYUANE} from '../constants';
 import {MongodbLottusEducationDataSource} from '../datasources';
 import {AcademicLevels} from '../models';
 
@@ -12,4 +13,20 @@ export class AcademicLevelsRepository extends DefaultCrudRepository<
   ) {
     super(AcademicLevels, dataSource);
   }
+
+  //change name of school to 'UTCBYUANE' or 'ULABYUANE' if are the modalities  1T, BO, 1P and school
+  async changeSchoolNameByModality(
+    levelCode: string,
+    school: string,
+  ) {
+    const levelsFilter = {school, identifier: SUBSCHOOL};
+    const levelsDoc = await this.findOne({
+      where: levelsFilter,
+    });
+    return levelsDoc?.levels.includes(levelCode)
+      ? school === UTC
+        ? UTCBYUANE
+        : ULABYUANE
+      : school;
+  };
 }

--- a/src/services/academic-record.service.ts
+++ b/src/services/academic-record.service.ts
@@ -1,9 +1,13 @@
 import {BindingScope, injectable, service} from '@loopback/core';
 import {CommonPropertiesService} from '.';
-import {ACADEMIC_RECORD, ULA, UTC} from '../constants';
-import {StudentData} from '../interfaces';
+import {
+  ACADEMIC_RECORD, DIGITAL_ULA_LABEL, DIGITAL_UTC_LABEL, ULA, UTC
+} from '../constants';
+import {
+  CommonServiceFields_ULA, CommonServiceFields_UTC, StudentData
+} from '../interfaces';
 import {CommonsRB} from '../models';
-import {logMethodAccessInfo, schoolError} from '../utils';
+import {logMethodAccessInfo, logger, schoolError} from '../utils';
 
 @injectable({scope: BindingScope.TRANSIENT})
 export class AcademicRecordService {
@@ -18,23 +22,49 @@ export class AcademicRecordService {
     requestBody: CommonsRB,
   ) {
     logMethodAccessInfo(this.setAcademicRecordServiceProperties.name);
+    let serviceObject: CommonServiceFields_ULA | CommonServiceFields_UTC;
+    let deliveryLabel: string;
+    let saveProcedureData = false;
     switch (studentData.school) {
       case ULA:
-        return this.commonPropertiesService.
+        serviceObject = await this.commonPropertiesService.
           setCommonPropertiesUlaWithDeliveryAndCampus(
             studentData,
             requestBody,
             ACADEMIC_RECORD
           );
+        deliveryLabel = serviceObject.Forma_de_Entrega__c!;
+        if (deliveryLabel === DIGITAL_ULA_LABEL) saveProcedureData = true;
+        this.logIfDataWillBeSaved(saveProcedureData, deliveryLabel)
+        return {serviceObject, saveProcedureData}
       case UTC:
-        return this.commonPropertiesService.
+        serviceObject = await this.commonPropertiesService.
           setCommonPropertiesUtcWithDeliveryAndCampus(
             studentData,
             requestBody,
             ACADEMIC_RECORD
           );
+        deliveryLabel = serviceObject.Tipo_de_Entrega_UTC__c!;
+        if (deliveryLabel === DIGITAL_UTC_LABEL) saveProcedureData = true;
+        this.logIfDataWillBeSaved(saveProcedureData, deliveryLabel);
+        return {serviceObject, saveProcedureData}
       default:
         throw schoolError(studentData.school);
     }
   }
+
+  logIfDataWillBeSaved(
+    saveProcedureData: boolean,
+    deliveryLabel: string
+  ) {
+    if (saveProcedureData)
+      logger.info(
+        `Delivery is '${deliveryLabel}', data will be saved for validation`
+      );
+    else
+      logger.info(
+        `Delivery is '${deliveryLabel}', data will not be saved for validation`
+      );
+  }
+
 }

--- a/src/services/proof-of-study.service.ts
+++ b/src/services/proof-of-study.service.ts
@@ -32,7 +32,6 @@ import {
   ProofOfStudyRepository,
 } from '../repositories';
 import {
-  changeSchoolNameByModality,
   costsError,
   logMethodAccessDebug,
   logMethodAccessInfo,
@@ -100,11 +99,11 @@ export class ProofOfStudyService {
       `Fetching detailCodes for school: ${school} and procedure: ${procedure}`,
     );
     //verify levelcode for change name of school by UANE only levels 1T, BO, !P
-    const changedSchool = await changeSchoolNameByModality(
-      academicLevel,
-      school,
-      this.academicLevelsRepository,
-    );
+    const changedSchool =
+      await this.academicLevelsRepository.changeSchoolNameByModality(
+        academicLevel,
+        school,
+      );
     let detailIdProofOfStudyArray = await this.detailCodesRepository.find({
       where: {school: changedSchool, procedure},
     });
@@ -191,11 +190,11 @@ export class ProofOfStudyService {
   ): Promise<ProcedureWithCost[]> {
     logMethodAccessDebug(this.getProofOfStudyWithCostsArrayForUla.name);
     //verify levelcode for change name school to 'UTCBYUANE' or 'ULABYUANE' only levels 1T, BO, !P
-    const changedSchool = await changeSchoolNameByModality(
-      academicLevel,
-      school,
-      this.academicLevelsRepository,
-    );
+    const changedSchool =
+      await this.academicLevelsRepository.changeSchoolNameByModality(
+        academicLevel,
+        school,
+      );
     // FETCH PROOFOFSTUDIES AND DETAIL CODES COLLECTIONS
     const procedure = PROOF_OF_STUDY;
     const filter = {

--- a/src/services/study-certificate-get.service.ts
+++ b/src/services/study-certificate-get.service.ts
@@ -34,7 +34,6 @@ import {
   StudyCertificateRepository,
 } from '../repositories';
 import {
-  changeSchoolNameByModality,
   costsError,
   logMethodAccessDebug,
   logMethodAccessInfo,
@@ -177,10 +176,10 @@ export class StudyCertificateGetService {
     logMethodAccessInfo(this.setCertificateWithCostArray.name);
     const {school, modality} = studentData;
     //verify levelcode for change name of school by UANE only levels 1T, BO, !P
-    const changedSchool = await changeSchoolNameByModality(
+    const changedSchool =
+    await this.academicLevelsRepository.changeSchoolNameByModality(
       studentData.levelCode,
       school,
-      this.academicLevelsRepository,
     );
     // Fetch detail codes
     let dcStudyCertArray: DetailCodes[];

--- a/src/services/transaction-number.service.ts
+++ b/src/services/transaction-number.service.ts
@@ -12,7 +12,6 @@ import {
 import {StudentData} from '../interfaces';
 import {AcademicLevelsRepository, DetailCodesRepository} from '../repositories';
 import {
-  changeSchoolNameByModality,
   getStudentData,
   logMethodAccessDebug,
   logMethodAccessInfo,
@@ -42,10 +41,10 @@ export class TransactionNumberService {
   ): Promise<number | null> {
     logMethodAccessDebug(this.getTransactionNumber.name);
     // verify levelcode to change name school to 'UTCBYUANE' or 'ULABYUANE' only levels 1T, BO, !P
-    const changedSchool = await changeSchoolNameByModality(
+    const changedSchool =
+    await this.academicLevelsRepository.changeSchoolNameByModality(
       studentData.levelCode,
       studentData.school,
-      this.academicLevelsRepository,
     );
     const detailCode = await this.fetchDetailCode(
       procedure,

--- a/src/utils/utilities.ts
+++ b/src/utils/utilities.ts
@@ -2,8 +2,6 @@
 ///////////////   UTILITIES   ////////////////
 
 import {logger} from '.';
-import {SUBSCHOOL, ULABYUANE, UTC, UTCBYUANE} from '../constants';
-import {AcademicLevelsRepository} from '../repositories';
 
 export const logMethodAccessInfo = (methodName: string) => {
   logger.info(`${methodName}() accessed`);
@@ -80,21 +78,4 @@ export const parseDate = (input: string) => {
   const parts = input.match(/(\d+)/g);
   // new Date(year, month [, date [, hours[, minutes[, seconds[, ms]]]]])
   return new Date(+parts![0], +parts![1] - 1, +parts![2]); // months are 0-based
-};
-
-//change name of school to 'UTCBYUANE' or 'ULABYUANE' if are the modalities  1T, BO, 1P and school
-export const changeSchoolNameByModality = async (
-  levelCode: string,
-  school: string,
-  academicLevelsRepository: AcademicLevelsRepository,
-) => {
-  const levelsFilter = {school, identifier: SUBSCHOOL};
-  const levelsDoc = await academicLevelsRepository.findOne({
-    where: levelsFilter,
-  });
-  return levelsDoc?.levels.includes(levelCode)
-    ? school === UTC
-      ? UTCBYUANE
-      : ULABYUANE
-    : school;
 };


### PR DESCRIPTION
## [2.4.0] - 2024-02-27

René Alejandro Rivas

### Changed:
- Academic record unit test updated
- AcademicRecord controller: validation added to save data just for digital procedures
- AcademicRecord Service: now validates delivery label and sends a flag to the
controller to state if delivery is digital or not
- changeSchoolNameByModality() moved from utilities to AcademicLevelsRepository
to avoid circular dependency
- ProofOfStudyService, StudyCertificateService & TransactionNumberService now consume
changeSchoolNameByModality() from AcademicLevelsRepository