### PR TITLE
Study-Certificate delivery just campus option for ULA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 
 # Changelog - SchoolServices - ConstHistCert
 
+## [2.6.0] - 2024-06-20
+René Alejandro Rivas
+
+### Changed
+- StudyCertificateController: GET now uses fetchPhysicalDeliveryAndCampusArrays()
+to get delivery and campus arrays
+- DeliveryRepository: fetchDeliveryWithSchool() & fetchDeliveryWithQr() removed
+- CommonPropertiesService: fetchPhysicalDeliveryAndCampusArrays() to get
+delivery array just with the physical option
+
 ## [2.5.1] - 2024-05-21
 René Alejandro Rivas
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "school-services-consthistcert",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "description": "Espacio: SchoolServices CHC microservice",
   "keywords": [
     "loopback-application",

--- a/public/index.html
+++ b/public/index.html
@@ -84,7 +84,7 @@
   <body>
     <div class="info">
       <h1>school-services-consthistcert</h1>
-      <p>Version 2.5.1</p>
+      <p>Version 2.6.0</p>
 
       <h3>OpenAPI spec: <a href="/openapi.json">/openapi.json</a></h3>
       <h3>API Explorer: <a href="/explorer">/explorer</a></h3>

--- a/src/controllers/study-certificate.controller.ts
+++ b/src/controllers/study-certificate.controller.ts
@@ -213,7 +213,7 @@ export class StudyCertificateController {
       );
     const {delivery, campus} =
       await this.studyCertificatePostService.commonPropertiesService.
-        fetchDeliveryAndCampusArrays(
+        fetchPhysicalDeliveryAndCampusArrays(
           school,
         );
 

--- a/src/repositories/delivery.repository.ts
+++ b/src/repositories/delivery.repository.ts
@@ -15,21 +15,8 @@ export class DeliveryRepository extends DefaultCrudRepository<
     super(Delivery, dataSource);
   }
 
-
-  async fetchDeliveryWithSchool(school: string){
-    logMethodAccessDebug(this.fetchDeliveryWithSchool.name);
-    const filter = {school};
-    return this.fetchDeliveryArray(filter);
-  }
-
-
-  async fetchDeliveryWithQr() {
-    logMethodAccessDebug(this.fetchDeliveryWithQr.name);
-    const filter = {identifier: "QR"}
-    return this.fetchDeliveryArray(filter);
-  }
-
-  private async fetchDeliveryArray(filter: object) {
+  async fetchDeliveryArray(filter: object) {
+    logMethodAccessDebug(this.fetchDeliveryArray.name);
     const deliveryArray = await this.find({where: filter});
     if (!deliveryArray.length)
       throw noDocFoundError(

--- a/src/services/common-properties.service.ts
+++ b/src/services/common-properties.service.ts
@@ -10,6 +10,7 @@ import {
   CAMPUS_COLLECTION_NAME,
   CAMPUS_DELIVERY_VALUE,
   DELIVERY_COLLECTION_NAME,
+  ULA,
 } from '../constants';
 import {
   CommonServiceFields_ULA,
@@ -39,7 +40,7 @@ export class CommonPropertiesService {
   async fetchDeliveryAndCampusArrays(school: string) {
     logMethodAccessTrace(this.fetchDeliveryAndCampusArrays.name);
     const delivery =
-      await this.deliveryRepository.fetchDeliveryWithSchool(school);
+      await this.deliveryRepository.fetchDeliveryArray({school});
     const campus = await this.campusRepository.fetchCampusArray(school);
     return {delivery, campus};
   }
@@ -47,7 +48,21 @@ export class CommonPropertiesService {
   async fetchDeliveryWithQrAndCampusArrays(school: string) {
     logMethodAccessTrace(this.fetchDeliveryAndCampusArrays.name);
     const delivery =
-      await this.deliveryRepository.fetchDeliveryWithQr();
+      await this.deliveryRepository.fetchDeliveryArray({identifier: "QR"});
+    const campus = await this.campusRepository.fetchCampusArray(school);
+    return {delivery, campus};
+  }
+
+  async fetchPhysicalDeliveryAndCampusArrays(school: string) {
+    logMethodAccessTrace(this.fetchPhysicalDeliveryAndCampusArrays.name);
+    let deliveryFilter: object = {school}
+    if (school === ULA)
+      deliveryFilter = {
+        school,
+        value: "ENTE7E2C6"
+      }
+    const delivery =
+      await this.deliveryRepository.fetchDeliveryArray(deliveryFilter);
     const campus = await this.campusRepository.fetchCampusArray(school);
     return {delivery, campus};
   }


### PR DESCRIPTION
## [2.6.0] - 2024-06-20
René Alejandro Rivas

### Changed
- StudyCertificateController: GET now uses fetchPhysicalDeliveryAndCampusArrays()
to get delivery and campus arrays
- DeliveryRepository: fetchDeliveryWithSchool() & fetchDeliveryWithQr() removed
- CommonPropertiesService: fetchPhysicalDeliveryAndCampusArrays() to get
delivery array just with the physical option

![image](https://github.com/techlottus/EspacioFormalitiesCHC/assets/157767431/be754301-484c-4916-b623-bdb7006ff056)

