### PR TITLE
Fix/return create id with prefix one caracter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog - SchoolServices - ConstHistCert
 
-## [2.6.1] - 2025-08-16
+## [2.6.2] - 2025-08-16
 
 Eduardo izquierdo Rojas
-fix in function createIdWithPrefix() when creating values
+return function createIdWithPrefix() when creating values with one caracter
 
 - src/utils/utilities.ts
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "school-services-consthistcert",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Espacio: SchoolServices CHC microservice",
   "keywords": [
     "loopback-application",

--- a/src/utils/utilities.ts
+++ b/src/utils/utilities.ts
@@ -62,9 +62,7 @@ export const createIdWithPrefix = (
   const listWords = inputString.toUpperCase().split(' ');
   let identifier = '';
   listWords.forEach(word => {
-    const firstTwoChars =
-      word.length >= 2 ? word.substring(0, 2) : word.charAt(0);
-    identifier += firstTwoChars + word.length;
+    identifier += word.charAt(0) + word.length;
   });
   identifier = prefix.substring(0, 3).toUpperCase() + identifier;
   if (listWords.length === 1) {


### PR DESCRIPTION
# Changelog - SchoolServices - ConstHistCert

## [2.6.2] - 2025-08-16

Eduardo izquierdo Rojas
return function createIdWithPrefix() when creating values with one caracter

- src/utils/utilities.ts
- 
<img width="881" height="467" alt="image" src="https://github.com/user-attachments/assets/0d50e2f3-c2b8-47ac-9def-91c29f513b73" />
